### PR TITLE
Update nodeless-puppet/modules/truth/plugins/puppet/parser/functions/has...

### DIFF
--- a/nodeless-puppet/modules/truth/plugins/puppet/parser/functions/has_role.rb
+++ b/nodeless-puppet/modules/truth/plugins/puppet/parser/functions/has_role.rb
@@ -18,9 +18,13 @@ module Puppet::Parser::Functions
       args = [args]
     end
     role = args[0]
-    roles = lookupvar("server_tags").split(",").grep(/^role:/)
-    roletag_re = /^role:#{role}(?:=.+)?$/
-    has_role = (roles.grep(roletag_re).length > 0)
-    return has_role
+    if lookupvar('server_tags') =~ /role:/
+      roles = lookupvar('server_tags').split(",").grep(/^role:/)
+      roletag_re = /^role:#{role}(?:=.+)?$/
+      has_role = (roles.grep(roletag_re).length > 0)
+      return has_role
+    else
+     false
+    end
   end # puppet function has_role
 end # module Puppet::Parser::Functions


### PR DESCRIPTION
..._role.rb
I am using this function but noticed two things.  If the facter variable server_tags is not defined on the host it throws a "private method `split' called for :undefined:Symbol"

After that was solved the statements in truth::enforcer are evaluated when the  facter variable server_tags is not defined

I am not a ruby guy as yet but learnt a few things sorting this out. It works for me anyhow.  

Please amend the code so that it behaves better than what i coded
